### PR TITLE
Fixed typo on the doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Connects two elements. If called multiple times, the lines will be curved.
 - **Object** `options`: An object containing the following fields:
  - `container` (SVGElement): The line elements container.
  - `markers` (SVGElement): The marker elements container.
+ - `padEllipse` (Boolean): If `true`, the line coordinates will be placed with a padding.
 - **SVGElement** `elmTarget`: The target SVG element.
 
 #### Return
@@ -83,7 +84,6 @@ Connects two elements. If called multiple times, the lines will be curved.
  - `target` (SVGElement): The target element.
  - `line` (SVGElement): The line element.
  - `marker` (SVGElement): The marker element.
- - `padEllipe` (Boolean): If `true`, the line coordinates will be placed with a padding.
  - [`computeLineCoordinates` (Function)](#computelinecoordinatescon)
  - [`update` (Function)](#update)
  - [`setLineColor` (Function)](#setlinecolorcolor-c)

--- a/dist/svg.connectable.js
+++ b/dist/svg.connectable.js
@@ -23,6 +23,7 @@ var _connections = {}
  *
  *  - `container` (SVGElement): The line elements container.
  *  - `markers` (SVGElement): The marker elements container.
+ *  - `padEllipse` (Boolean): If `true`, the line coordinates will be placed with a padding.
  *
  * @param {SVGElement} elmTarget The target SVG element.
  * @return {Object} The connectable object containing:
@@ -31,7 +32,6 @@ var _connections = {}
  *  - `target` (SVGElement): The target element.
  *  - `line` (SVGElement): The line element.
  *  - `marker` (SVGElement): The marker element.
- *  - `padEllipe` (Boolean): If `true`, the line coordinates will be placed with a padding.
  *  - [`computeLineCoordinates` (Function)](#computelinecoordinatescon)
  *  - [`update` (Function)](#update)
  *  - [`setLineColor` (Function)](#setlinecolorcolor-c)

--- a/example/js/svg.connectable.js
+++ b/example/js/svg.connectable.js
@@ -23,6 +23,7 @@ var _connections = {}
  *
  *  - `container` (SVGElement): The line elements container.
  *  - `markers` (SVGElement): The marker elements container.
+ *  - `padEllipse` (Boolean): If `true`, the line coordinates will be placed with a padding.
  *
  * @param {SVGElement} elmTarget The target SVG element.
  * @return {Object} The connectable object containing:
@@ -31,7 +32,6 @@ var _connections = {}
  *  - `target` (SVGElement): The target element.
  *  - `line` (SVGElement): The line element.
  *  - `marker` (SVGElement): The marker element.
- *  - `padEllipe` (Boolean): If `true`, the line coordinates will be placed with a padding.
  *  - [`computeLineCoordinates` (Function)](#computelinecoordinatescon)
  *  - [`update` (Function)](#update)
  *  - [`setLineColor` (Function)](#setlinecolorcolor-c)

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,6 +22,7 @@ var _connections = {}
  *
  *  - `container` (SVGElement): The line elements container.
  *  - `markers` (SVGElement): The marker elements container.
+ *  - `padEllipse` (Boolean): If `true`, the line coordinates will be placed with a padding.
  *
  * @param {SVGElement} elmTarget The target SVG element.
  * @return {Object} The connectable object containing:
@@ -30,7 +31,6 @@ var _connections = {}
  *  - `target` (SVGElement): The target element.
  *  - `line` (SVGElement): The line element.
  *  - `marker` (SVGElement): The marker element.
- *  - `padEllipe` (Boolean): If `true`, the line coordinates will be placed with a padding.
  *  - [`computeLineCoordinates` (Function)](#computelinecoordinatescon)
  *  - [`update` (Function)](#update)
  *  - [`setLineColor` (Function)](#setlinecolorcolor-c)

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "contributors": [
     "Ionică Bizău <bizauionica@gmail.com>",
     "https://github.com/eperry",
-    "@squeamish-ossifrage (https://github.com/squeamish-ossifrage)"
+    "@squeamish-ossifrage (https://github.com/squeamish-ossifrage)",
+    "Hiroki Kiyohara (hirokiky@gmail.com)"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
I found typo on the doc.

* `padEllipe` => `padEllipse`
* `padEllipse` is a param, not returned value.

(Does this PR follows the contributing guide correctly?
